### PR TITLE
enable support on linux systems without docker desktop

### DIFF
--- a/examples/ethereum/e2esuite/jackal_relay.go
+++ b/examples/ethereum/e2esuite/jackal_relay.go
@@ -70,6 +70,7 @@ func RunContainerWithConfig(image string, containerName string, localConfigPath 
 			Cmd: []string{"sleep", "3600"}, // Example: long-running command
 		},
 		&container.HostConfig{
+			NetworkMode: "host",
 			Binds: []string{
 				fmt.Sprintf("%s:/root/.mulberry/config.yaml", localConfigPath),
 			},

--- a/examples/ethereum/e2esuite/mulberry_config.yaml
+++ b/examples/ethereum/e2esuite/mulberry_config.yaml
@@ -6,7 +6,7 @@ jackal_config:
 networks_config:
 - name: Ethereum Sepolia
   rpc: http://127.0.0.1:8545
-  ws: ws://host.docker.internal:8545
+  ws: ws://127.0.0.1:8545
   contract: 0xCustomContractAddress
   chain_id: 11155111
   finality: 2

--- a/examples/ethereum/forge_test.go
+++ b/examples/ethereum/forge_test.go
@@ -33,7 +33,7 @@ var (
 
 func (s *OutpostTestSuite) SetupForgeSuite(ctx context.Context) {
 	// Start Anvil node
-	anvilArgs := []string{"--port", "8545", "--block-time", "1"}
+	anvilArgs := []string{"--port", "8545", "--block-time", "1", "--host", "0.0.0.0"}
 	// easiest way to install anvil is foundryup --install stable
 	// you can modify the code to use docker container with --network host
 	output, err := eth.ExecuteCommand("anvil", anvilArgs)
@@ -99,7 +99,7 @@ func (s *OutpostTestSuite) SetupForgeSuite(ctx context.Context) {
 
 	// Update the YAML file
 	rpcAddress := "http://127.0.0.1:8545"
-	wsAddress := "ws://host.docker.internal:8545"
+	wsAddress := "ws://127.0.0.1:8545"
 	if err := e2esuite.UpdateMulberryConfigRPC(localConfigPath, "Ethereum Sepolia", rpcAddress, wsAddress); err != nil {
 		log.Fatalf("Failed to update mulberry config: %v", err)
 	}
@@ -243,7 +243,7 @@ func (s *OutpostTestSuite) TestForge() {
 	if err != nil {
 		log.Fatalf("Failed to connect to the Ethereum ws client: %v", err)
 	}
-	defer client.Close()
+	defer wsClient.Close()
 
 	go eth.ListenToLogs(wsClient, common.HexToAddress(ContractAddress))
 


### PR DESCRIPTION
This PR has the mulberry docker container share a network with a host, which is a feature available on all platforms.

Additionally, this enables our tests to run on Linux systems without Docker Desktop, like Github Actions runners.